### PR TITLE
Add `--output-dir` functionality

### DIFF
--- a/lib/metanorma/m3aawg/processor.rb
+++ b/lib/metanorma/m3aawg/processor.rb
@@ -30,10 +30,6 @@ module Metanorma
         "Metanorma::M3AAWG #{Metanorma::M3AAWG::VERSION}"
       end
 
-      def input_to_isodoc(file, filename)
-        Metanorma::Input::Asciidoc.new.process(file, filename, @asciidoctor_backend)
-      end
-
       def output(isodoc_node, inname, outname, format, options={})
         case format
         when :html


### PR DESCRIPTION
move the Metanorma::M3AAWG::Processor#input_to_isodoc method to Metanorma::Processor
metanorma/metanorma-cli#134